### PR TITLE
Using right TLS/SSL class on HTTPS connections

### DIFF
--- a/ACalDAV/src/org/gege/caldavsyncadapter/caldav/CaldavFacade.java
+++ b/ACalDAV/src/org/gege/caldavsyncadapter/caldav/CaldavFacade.java
@@ -327,7 +327,7 @@ public class CaldavFacade {
         SchemeRegistry registry = new SchemeRegistry();
 		registry.register(new Scheme("http", new PlainSocketFactory(), 80));
         registry.register(new Scheme("https",
-                (mTrustAll ? EasySSLSocketFactory.getSocketFactory() : new PlainSocketFactory()), 443
+                (mTrustAll ? EasySSLSocketFactory.getSocketFactory() : new TlsSniSocketFactory()), 443
         ));
         return new DefaultHttpClient(
                 new ThreadSafeClientConnManager(params, registry), params);


### PR DESCRIPTION
Fixed bug introduced with previous pull request #15
