### PR TITLE
Fixed EXDATE handling from Android (should fix #13)

### DIFF
--- a/ACalDAV/src/org/gege/caldavsyncadapter/android/entities/AndroidEvent.java
+++ b/ACalDAV/src/org/gege/caldavsyncadapter/android/entities/AndroidEvent.java
@@ -153,6 +153,9 @@ public class AndroidEvent extends org.gege.caldavsyncadapter.Event {
     public boolean readContentValues(Cursor cur) {
         this.setETag(cur.getString(cur.getColumnIndex(ETAG)));
 
+        this.ContentValues.put(Events._ID, cur.getString(cur.getColumnIndex(Events._ID)));
+        this.ContentValues.put(Events.ORIGINAL_ID, cur.getString(cur.getColumnIndex(Events.ORIGINAL_ID)));
+        this.ContentValues.put(Events.ORIGINAL_SYNC_ID, cur.getString(cur.getColumnIndex(Events.ORIGINAL_SYNC_ID)));
         this.ContentValues.put(Events.EVENT_TIMEZONE,
                 cur.getString(cur.getColumnIndex(Events.EVENT_TIMEZONE)));
         this.ContentValues.put(Events.EVENT_END_TIMEZONE,


### PR DESCRIPTION
This should fix #13

Android creates a new event (marked as CANCELED) for each exception item in a recurring event, instead of settings EXDATEs. On sync'ing this behaviour is fixed by replacing each CANCELED recurring event to EXDATE.
